### PR TITLE
Use Path to load and wirte token as OS-neutral

### DIFF
--- a/lichs/__main__.py
+++ b/lichs/__main__.py
@@ -2,7 +2,7 @@ import sys
 import os
 import berserk
 import chess
-import pathlib
+from pathlib import Path
 
 #from .Game import Game
 #from .api_key import set_api
@@ -17,8 +17,8 @@ def main():
         os._exit(0)
     except:
         try:
-            with open(str(pathlib.Path(__file__).parent.absolute()) + "\\key.txt") as f:
-                token = f.read()
+            token_file = Path(__file__).parent.absolute() / "key"
+            token = token_file.read_text()
             session = berserk.TokenSession(token)
             client = berserk.clients.Client(session)
             board = berserk.clients.Board(session)

--- a/lichs/api_key.py
+++ b/lichs/api_key.py
@@ -1,9 +1,8 @@
 import sys
-import pathlib
+from pathlib import Path
 
 def set_api(key):
-    
-    file = open(str(pathlib.Path(__file__).parent.absolute()) + "\\key.txt", "w")
-    file.write(key)
-    file.close()
+
+    token_file = Path(__file__).parent.absolute() / "key"
+    token_file.write_text(key)
     print("The API-token " + key + " was entered and saved.")


### PR DESCRIPTION
The original code uses `\\key.txt`, but that doesn't work on Linux, it justs calls the file lichs\key.txt

But based on [this blog post](https://medium.com/@ageitgey/python-3-quick-tip-the-easy-way-to-deal-with-file-paths-on-windows-mac-and-linux-11a072b58d5f), you can just use :

`Path(__file__).parent.absolute() / "key"`

And it will deal with the OS specific path (`\` for Windows, and `/` for Linux/MacOS).
I also decided to add the read and write methods from Path, which imo makes the code cleaner.

 And since we are being OS-neutral, we might as well just use `key` instead of `key.txt`