### PR TITLE
Restore import statements

### DIFF
--- a/lichs/__main__.py
+++ b/lichs/__main__.py
@@ -4,8 +4,8 @@ import berserk
 import chess
 from pathlib import Path
 
-from Game import Game
-from api_key import set_api
+from lichs.Game import Game
+from lichs.api_key import set_api
 
 
 def main():


### PR DESCRIPTION
I apologize again, I've never used pypi before (whatever error I experienced earlier requiring removal of "lichs" from the import statements is no longer reproducible):

```
~/.local/bin/lichs
Traceback (most recent call last):
  File "/home/lila/.local/bin/lichs", line 5, in <module>
    from lichs.__main__ import main
  File "/home/lila/.local/lib/python3.8/site-packages/lichs/__main__.py", line 7, in <module>
    from Game import Game
ModuleNotFoundError: No module named 'Game'
```